### PR TITLE
restore Number(::Static) constructor

### DIFF
--- a/src/StaticNumbers.jl
+++ b/src/StaticNumbers.jl
@@ -100,6 +100,9 @@ Base.promote_rule(::Type{<:Static{X}}, ::Type{T}) where {X,T<:Number} =
 # Bool has a special rule that we need to override?
 #Base.promote_rule(::Type{Bool}, ::Type{StaticInteger{X}}) where {X} = promote_type(Bool, typeof(X))
 
+(::Type{T})(::Static{X}) where {T<:Number,X} = T(X)
+Base.BigInt(::Static{X}) where {X} = BigInt(X)
+
 "ofstatictype(x,y) - like oftype(x,y), but return a `Static` `x` is a `Static`."
 ofstatictype(::Static{X}, y) where {X} = static(oftype(X, y))
 ofstatictype(x, y) = oftype(x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,3 +233,5 @@ C = A[staticlength(5:8),StaticOneTo(4)]
 A[StaticOneTo(4),StaticOneTo(4)] = C
 @test all(A[StaticOneTo(4),StaticOneTo(4)] .== C)
 @test all(staticlength(3:4).^2 == (3:4).^2)
+
+@test Unsigned(static(2)) === Unsigned(2)


### PR DESCRIPTION
Sorry, I accidentally removed some functionality in #1. Restored with test.