### PR TITLE
fix test for julia v1.2

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ for x in (-1.0, -1, 2, 3, 1.5, 2.0, 3.1, pi, 3//2, 3.0+im)
         @test static(x) + static(y) === x + y
         for f in (:-, :*, :/, :^, :rem, :mod, :(<<), :(>>), :(==), :(<), :(<=), :(>), :(>=))
             r = try
-                @eval $f($x,$y)
+                f(x,y)
             catch
                 nothing
             end


### PR DESCRIPTION
The problem here is that `x^y` is lowered differently when y is the literal constant -1, so I switched away from `eval` to hide the constant from the front end.