### PR TITLE
Make setindex(::Tuple, _, ::StaticInteger) inferrable

### DIFF
--- a/src/StaticNumbers.jl
+++ b/src/StaticNumbers.jl
@@ -222,6 +222,11 @@ Base.:/(::StaticNumber{X}, y::Real) where {X} = X/y
 Base.:*(::StaticNumber{X}, y::Real) where {X} = X*y
 Base.:*(x::Real, ::StaticNumber{Y}) where {Y} = x*Y
 
+@inline function Base.setindex(x::Tuple, v, i::StaticInteger)
+    @boundscheck 1 <= i <= length(x) || throw(BoundsError(x, i))
+    return ntuple(n -> n == i ? v : x[n], length(x))
+end
+
 include("generate_static_methods.jl")
 
 include("LengthRanges.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -441,4 +441,12 @@ end
     @test static(UInt(2)) >= static(-1)
 end
 
+@testset "setindex(::Tuple, _, ::StaticInteger)" begin
+    @test @inferred(Base.setindex((1, 2, 3), nothing, static(1))) == (nothing, 2, 3)
+    @test @inferred(Base.setindex((1, 2, 3), nothing, static(2))) == (1, nothing, 3)
+    @test @inferred(Base.setindex((1, 2, 3), nothing, static(3))) == (1, 2, nothing)
+    @test_throws BoundsError Base.setindex((1, 2, 3), nothing, static(0))
+    @test_throws BoundsError Base.setindex((1, 2, 3), nothing, static(4))
+end
+
 include("StaticArrays_test.jl")


### PR DESCRIPTION
fix #5

FYI this is how `Base.setindex` is defined https://github.com/JuliaLang/julia/blob/7e6ef91c9d0bf89de7b45a46aaacf4f644986b69/base/tuple.jl#L44-L54