### PR TITLE
Fix at-stat; do not assume maybe_static to exist

### DIFF
--- a/src/stat_macro.jl
+++ b/src/stat_macro.jl
@@ -33,26 +33,26 @@ Turn all constants in an expression into `static` and all
 function calls into `trystatic`.
 """
 statify(ex) = ex
-statify(x::Number) = :( static($x) )
+statify(x::Number) = :( $static($x) )
 statify(x::Unsigned) = x
 function statify(ex::Expr)
     if ex.head == :call
         if first(string(ex.args[1])) == '.'  #for example: .+
             # TODO: We should handle breadcasted maybe_static.
-            # Expr(:., :maybe_static, Expr(:tuple, Symbol(string(ex.args[1])[2:end]), map(statify, ex.args[2:end])...))
+            # Expr(:., maybe_static, Expr(:tuple, Symbol(string(ex.args[1])[2:end]), map(statify, ex.args[2:end])...))
             Expr(ex.head, map(statify, ex.args)...)
         elseif ex.args[1] ∈ (:oftype, :typeof)
             # Changing the type of the argument(s) makes no sense for these functions
-            Expr(ex.head, :maybe_static, ex.args...)
+            Expr(ex.head, maybe_static, ex.args...)
         else
-            Expr(ex.head, :maybe_static, map(statify, ex.args)...)
+            Expr(ex.head, maybe_static, map(statify, ex.args)...)
         end
     #elseif ex.head == :.
-    #    Expr(:., :maybe_static, Expr(:tuple, ex.args[1], map(statify, ex.args[2].args)...))
+    #    Expr(:., maybe_static, Expr(:tuple, ex.args[1], map(statify, ex.args[2].args)...))
     elseif ex.head ∈ (:if, :&&, :||, :(=))
         Expr(ex.head, ex.args[1], map(statify, ex.args[2:end])...)
     elseif ex.head == :ref
-        Expr(ex.head, :( StaticNumbers.MaybeStatic($(statify(ex.args[1]))) ), map(statify, ex.args[2:end])...)
+        Expr(ex.head, :( $StaticNumbers.MaybeStatic($(statify(ex.args[1]))) ), map(statify, ex.args[2:end])...)
     else
         Expr(ex.head, map(statify, ex.args)...)
     end

--- a/test/StaticArrays_test.jl
+++ b/test/StaticArrays_test.jl
@@ -63,6 +63,10 @@ end
     Test.@inferred(g(static(2)))
 
     @test SVector(i^2 for i in static(1):static(3)) === SVector{3}([1, 4, 9])
+
+    @test CleanNamespace.get_one_to(SVector(1, 2, 3), static(2)) === SVector(1, 2)
+    @test CleanNamespace.get_one_to(MVector(1, 2, 3), static(2)) == MVector(1, 2)
+    @test CleanNamespace.get_one_to(MVector(1, 2, 3), static(2)) isa MVector
 end
 
 @inline function testmul(A::SMatrix, B::SMatrix)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,6 +418,15 @@ end
     @test LengthUnitRange(2:4) == 2:4
 end
 
+# Expand `@stat` in a clean namespace to avoid assuming anything in
+# the expanding namespace.
+module CleanNamespace
+using StaticNumbers: @stat
+add_literal_one(x) = @stat x + 1
+add(x, y) = @stat x + y
+get_one_to(x, i) = @stat x[1:i]
+end
+
 @testset "@stat macro" begin
     @test @stat(2+2) === static(4)
     x = 2
@@ -469,6 +478,11 @@ end
     @test (2,3) === @stat T[2:end-1]
     @test (2,3) === @stat T[range(2, length=2)]
     Test.@inferred T[range(2, length=static(2))]
+
+    @test CleanNamespace.add_literal_one(0) === 1
+    @test CleanNamespace.add_literal_one(static(0)) === static(1)
+    @test CleanNamespace.add(static(0), 1) === 1
+    @test CleanNamespace.add(static(0), static(1)) === static(1)
 end
 
 tuple_test(n) = Tuple(i for i in static(1):n)


### PR DESCRIPTION
`@stat` assumes that `maybe_static` etc. exist in the namespace. This is a simple patch to make

```julia
module CleanNamespace
using StaticNumbers: @stat
add_literal_one(x) = @stat x + 1
end
```

work. I just embed the actual object in the AST instead of the symbol. Alternatively, you can narrow expressions applied to `esc`. But I think this patch is simpler.