### PR TITLE
Avoid warning from kwargs.data

### DIFF
--- a/src/stat_macro.jl
+++ b/src/stat_macro.jl
@@ -13,7 +13,7 @@ functions under the macro.
 @inline function maybe_static(f::F, args...; kwargs...) where {F}
     y = f(args...; kwargs...)
     if y isa Number && !(y isa Bool) && !(y isa Unsigned) &&
-            all(map(a->a isa Static, args)) && all(map(a->a isa Static, kwargs.data))
+            all(map(a->a isa Static, args)) && all(map(a->a isa Static, values(kwargs)))
         static(y)
     else
         y


### PR DESCRIPTION
As of Julia 1.7, using `@stat` macro gives me this warning:

```
(@v1.7) pkg> activate --temp
  Activating new project at `/tmp/jl_rLFihA`

julia> using StaticNumbers
 │ Package StaticNumbers not found, but a package named StaticNumbers is available from a registry.
 │ Install package?
 │   (jl_rLFihA) pkg> add StaticNumbers
 └ (y/n) [y]: y
...

(jl_rLFihA) pkg> st
      Status `/tmp/jl_rLFihA/Project.toml`
  [c5e4b96a] StaticNumbers v0.3.3

julia> using StaticNumbers

julia> x = @stat(1)
static(1)

julia> @stat(x + 1)
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = #maybe_static#20 at stat_macro.jl:15 [inlined]
└ @ Core ~/.julia/packages/StaticNumbers/1M5qL/src/stat_macro.jl:15
static(2)
```

This PR implements the suggested fix and avoids the performance degradation due to this.
